### PR TITLE
Use newer Ubuntu runner for Hugo deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Found at:
 
 https://arran4.github.io/blog/
 
+Subscribe to new posts via RSS:
+https://arran4.github.io/blog/index.xml
+
 ## Random notes / snippets
 
 ### Create a new post

--- a/config.toml
+++ b/config.toml
@@ -18,7 +18,7 @@ defaultContentLanguage = "en"
     filename = "sitemap.xml"
 
 [params]
-    rssFullContent = true     # if false, Rss feed instead of the summary
+    rssFullContent = false     # use post summaries in the RSS feed
     dateFormatToUse = "2006-01-02"
 
     logoTitle = "Arran's Technical Blog"

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -17,21 +17,14 @@
     {{ with .OutputFormats.Get "RSS" }}
 	{{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
-    {{ range first 50 (where .Site.RegularPages "Type" "in" (slice "news" "showcase")) }}
+    {{ range first 50 .Site.RegularPages }}
     <item>
-      <title>{{ .Section | title }}: {{ .Title }}</title>
+      <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
-      <description>
-        {{ $img := (.Resources.ByType "image").GetMatch "*featured*" }}
-        {{ with $img }}
-        {{ $img := .Resize "640x" }}
-        {{ printf "<![CDATA[<img src=\"%s\" width=\"%d\" height=\"%d\"/>]]>" $img.Permalink $img.Width $img.Height | safeHTML }}
-        {{ end }}
-        {{ .Content | html }}
-      </description>
+      <description>{{ .Summary | html }}</description>
     </item>
     {{ end }}
   </channel>


### PR DESCRIPTION
## Summary
- update workflow to use `ubuntu-latest`
- RSS feed now uses summaries and README shows the feed URL

## Testing
- `hugo --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684cd9527dfc832faaebaa76386af39e