### PR TITLE
Add author email for RSS feed

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,7 @@ defaultContentLanguage = "en"
     languageCode = "en"
 [author]
     name = 'Arran Ubels'
+    email = "technicalblog123@arran4.com"
 
 [sitemap]                 # essential                     # 必需
     changefreq = "weekly"
@@ -18,6 +19,10 @@ defaultContentLanguage = "en"
     filename = "sitemap.xml"
 
 [params]
+  [params.author]
+    name = "Arran Ubels"
+    email = "technicalblog123@arran4.com"
+
     rssFullContent = false     # use post summaries in the RSS feed
     dateFormatToUse = "2006-01-02"
 


### PR DESCRIPTION
## Summary
- define author email in config
- include `[params.author]` for theme compatibility

## Testing
- `hugo -s .`

------
https://chatgpt.com/codex/tasks/task_e_6869b46e80fc832f827860431c991d2c