### PR TITLE
Add blog post on runner image update

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -144,5 +144,9 @@
     "fileinto",
     "struct",
     "DMARC",
-    "dmarc"
-  ]}
+    "dmarc",
+    "Ubels",
+    "libicu",
+    "usermod"
+  ]
+}

--- a/content/post/2025/005-Runner-Docker-Permissions-Fix/index.md
+++ b/content/post/2025/005-Runner-Docker-Permissions-Fix/index.md
@@ -1,0 +1,29 @@
+---
+title: "Fixing Docker Permissions in the Self-Hosted Runner Image"
+date: 2025-07-08T15:00:00+10:00
+draft: false
+tags: ["github-actions", "docker", "devops"]
+categories: ["devops"]
+author: "Arran Ubels"
+---
+
+While testing the multi-runner setup I discovered containers started by the `runner` user could not invoke Docker. The base image lacked the `docker.io` package and the user was missing membership of the `docker` group.
+
+The `Dockerfile.ubuntu-runner` now installs Docker and ensures the `runner` user belongs to the `docker` group so each containerised runner can start sibling containers without needing root:
+
+```diff
+@@
+-RUN apt-get update && apt-get install -y \
+-      curl git jq sudo nodejs npm \
+-      libicu70 libssl-dev libcurl4-openssl-dev \
++RUN apt-get update && apt-get install -y \
++      curl git jq sudo nodejs npm \
++      libicu70 libssl-dev libcurl4-openssl-dev \
++      docker.io \
+     && rm -rf /var/lib/apt/lists/*
+@@
+-RUN useradd -m -s /bin/bash runner
++RUN useradd -m -s /bin/bash runner && usermod -a -G docker runner
+```
+
+With these tweaks the runner containers can spin up jobs that use Docker without permission errors.


### PR DESCRIPTION
## Summary
- add a blog post covering the docker permission fix for the self-hosted runner image
- extend cspell dictionary with new terms
- update blog post with extra group configuration
- revise docker permissions post to use final usermod command

## Testing
- `npx cspell "content/post/2025/005-Runner-Docker-Permissions-Fix/index.md"`
- `npx cspell "README.md" "content/**/*.md"` *(fails: Issues found in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_686ca7fe6664832fb54f6b151d57ab83