### PR TITLE
Fix cspell issues

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -147,6 +147,24 @@
     "dmarc",
     "Ubels",
     "libicu",
-    "usermod"
+    "usermod",
+    "BTOP",
+    "btop",
+    "urxvt",
+    "Alacritty",
+    "Qterminal",
+    "Consible",
+    "Sakura",
+    "erresc",
+    "ptyxis",
+    "mlterm",
+    "kterm",
+    "zutty",
+    "vterm",
+    "priv",
+    "Ghostty",
+    "roxterm",
+    "rxvt",
+    "Yeahconsole"
   ]
 }

--- a/content/post/2025/006-BTOP-running-in-various-terminals/index.md
+++ b/content/post/2025/006-BTOP-running-in-various-terminals/index.md
@@ -159,7 +159,7 @@ W [vterm.icc:1519] (Unimplemented) reset priv mode 2026
 0000001b[?2026h
 ```
 
-## ghosttty
+## Ghostty
 
 ![Screenshot_20250716_182418.png](Screenshot_20250716_182418.png)
 
@@ -171,9 +171,9 @@ W [vterm.icc:1519] (Unimplemented) reset priv mode 2026
 * rxvt
 * Consible Term
 
-# Skiped
+# Skipped
 * Yeahconsole
 
 # Contributions
 
-Feel free to PR a self attributed pr
+Feel free to PR a self attributed screenshot of your preferred terminal.


### PR DESCRIPTION
## Summary
- add missing terminal names to `.cspell.json`
- correct typos in the BTOP terminals post

## Testing
- `npx --yes cspell content/post/2025/006-BTOP-running-in-various-terminals/index.md`

------
https://chatgpt.com/codex/tasks/task_e_687761ff95b4832fa188d264a4c7dd08