### PR TITLE
docs: fix outdated CI snippets in github actions post

### DIFF
--- a/content/post/2026/006-Github-CI-and-Deploy/index.md
+++ b/content/post/2026/006-Github-CI-and-Deploy/index.md
@@ -531,9 +531,6 @@ linters:
     - errcheck
     - ineffassign
     - revive
-
-issues:
-  exclude-use-default: false
 ```
 
 ### `.prettierrc.json`
@@ -1803,6 +1800,7 @@ Copy/paste CI step style:
           TAG: ${{ needs.prepare-release-tag.outputs.release_tag }}
         run: |
           set -euo pipefail
+          git tag "$TAG"
           git push origin "$TAG" || { sleep 2; git push origin "$TAG"; }
       - name: Create release with generated notes + discussion
         env:


### PR DESCRIPTION
This PR updates the boilerplate CI code snippets in `content/post/2026/006-Github-CI-and-Deploy/index.md` to prevent readers from encountering issues that were recently fixed in the repository's own workflows.

- Adds the missing `git tag "$TAG"` command right before `git push origin "$TAG"` in the `manual-gh-release` job so that the push doesn't fail with `src refspec does not match any`.
- Removes the deprecated `exclude-use-default: false` setting under `issues` in the `.golangci.yml` snippet to resolve errors when running modern versions of `golangci-lint`.

---
*PR created automatically by Jules for task [11087189405864077201](https://jules.google.com/task/11087189405864077201) started by @arran4*