### PR TITLE
docs(ci): add cmake version bump example to GitHub Actions guide

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -327,6 +327,7 @@
     "baklz",
     "oneshot",
     "pathlib",
-    "btrfs"
+    "btrfs",
+    "kabc"
   ]
 }

--- a/content/post/2026/006-Github-CI-and-Deploy/index.md
+++ b/content/post/2026/006-Github-CI-and-Deploy/index.md
@@ -1790,11 +1790,14 @@ Copy/paste CI step style:
         run: |
           set -euo pipefail
           git fetch --tags --force
-          # For repos with a source-controlled version, compare it with the
-          # highest fetched tag and bump from whichever is newer.
-          # Example: CMAKE_VERSION=$(grep -Po 'project\(app VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
-          # TAG_VERSION=$(git tag -l "v*" | sed 's/^v//' | sort -V | tail -n 1)
-          # CURRENT_VERSION=$(echo -e "$CMAKE_VERSION\n$TAG_VERSION" | sort -V | tail -n 1)
+          # For repos with a source-controlled version, bump it to the release version
+          # and commit it before tagging (so the tag includes the bump).
+          # Example for CMake:
+          # RELEASE_VERSION="${{ needs.prepare-release-tag.outputs.release_tag }}"
+          # RELEASE_VERSION="${RELEASE_VERSION#v}"
+          # sed -i -E "s/project\(kabc VERSION [^)]+\)/project(kabc VERSION $RELEASE_VERSION)/" CMakeLists.txt
+          # git add CMakeLists.txt
+          # git commit -m "chore: bump release version to $RELEASE_VERSION"
       - name: Push prepared tag (retry)
         env:
           TAG: ${{ needs.prepare-release-tag.outputs.release_tag }}
@@ -1901,6 +1904,7 @@ This pattern from the referenced workflow is useful for repos that keep `-SNAPSH
 
           # Replace with repo-specific version bump command(s)
           # mvn versions:set -DnewVersion="$NEXT_VERSION" -DgenerateBackupPoms=false
+          # sed -i -E "s/project\(kabc VERSION [^)]+\)/project(kabc VERSION $NEXT_VERSION)/" CMakeLists.txt
 
           git add -A
           git commit -m "Prepare next development iteration $NEXT_VERSION"

--- a/content/post/2026/006-Github-CI-and-Deploy/index.md
+++ b/content/post/2026/006-Github-CI-and-Deploy/index.md
@@ -1795,7 +1795,7 @@ Copy/paste CI step style:
           # Example for CMake:
           # RELEASE_VERSION="${{ needs.prepare-release-tag.outputs.release_tag }}"
           # RELEASE_VERSION="${RELEASE_VERSION#v}"
-          # sed -i -E "s/project\(kabc VERSION [^)]+\)/project(kabc VERSION $RELEASE_VERSION)/" CMakeLists.txt
+          # sed -i -E "s/(project\([^ ]+ VERSION )[^ )]+/\1$RELEASE_VERSION/" CMakeLists.txt
           # git add CMakeLists.txt
           # git commit -m "chore: bump release version to $RELEASE_VERSION"
       - name: Push prepared tag (retry)
@@ -1904,7 +1904,7 @@ This pattern from the referenced workflow is useful for repos that keep `-SNAPSH
 
           # Replace with repo-specific version bump command(s)
           # mvn versions:set -DnewVersion="$NEXT_VERSION" -DgenerateBackupPoms=false
-          # sed -i -E "s/project\(kabc VERSION [^)]+\)/project(kabc VERSION $NEXT_VERSION)/" CMakeLists.txt
+          # sed -i -E "s/(project\([^ ]+ VERSION )[^ )]+/\1$NEXT_VERSION/" CMakeLists.txt
 
           git add -A
           git commit -m "Prepare next development iteration $NEXT_VERSION"


### PR DESCRIPTION
Adds a specific example for automatically bumping `project(kabc VERSION xyz)` inside `CMakeLists.txt` in GitHub Action workflow templates, covering both the release process and the next-iteration version bump as requested by the user.

---
*PR created automatically by Jules for task [9698974355084773001](https://jules.google.com/task/9698974355084773001) started by @arran4*