### PR TITLE
Switch commenting system from Utterances to Giscus

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -65,9 +65,3 @@ defaultContentLanguage = "en"
   theme = "light"
   lang = "en"
   lazyLoading = false
-
-[params.utteranc]
-  enable = false
-
-[params.utterances]
-  enable = false

--- a/config.toml
+++ b/config.toml
@@ -50,3 +50,24 @@ defaultContentLanguage = "en"
     guessSyntax = true
     lineNos = true
     noClasses = false
+
+[params.giscus]
+  enable = true
+  repo = "arran4/blog"
+  repoId = "R_kgDOHNgfGQ"
+  category = "Announcements"
+  categoryId = "DIC_kwDOHNgfGc4COv86"
+  mapping = "pathname"
+  strict = 0
+  reactionsEnabled = 1
+  emitMetadata = 0
+  inputPosition = "top"
+  theme = "light"
+  lang = "en"
+  lazyLoading = false
+
+[params.utteranc]
+  enable = false
+
+[params.utterances]
+  enable = false

--- a/themes/hugo-theme-jane/layouts/partials/comments.html
+++ b/themes/hugo-theme-jane/layouts/partials/comments.html
@@ -10,7 +10,6 @@
     {{ partial "comments/giscus.html" . }}
   {{ end }}
 
-
   <!-- changyan -->
   {{- if and .Site.Params.changyanAppid .Site.Params.changyanAppkey -}}
     {{ partial "comments/changyan.html" . }}

--- a/themes/hugo-theme-jane/layouts/partials/comments.html
+++ b/themes/hugo-theme-jane/layouts/partials/comments.html
@@ -10,10 +10,6 @@
     {{ partial "comments/giscus.html" . }}
   {{ end }}
 
-  <!-- utteranc -->
-  {{ if .Site.Params.utteranc.enable }}
-    {{ partial "comments/utteranc.html" . }}
-  {{ end }}
 
   <!-- changyan -->
   {{- if and .Site.Params.changyanAppid .Site.Params.changyanAppkey -}}

--- a/themes/hugo-theme-jane/layouts/partials/comments/utteranc.html
+++ b/themes/hugo-theme-jane/layouts/partials/comments/utteranc.html
@@ -1,9 +1,0 @@
-<div class="post">
-  <script src="https://utteranc.es/client.js"
-        repo= "{{ .Site.Params.utteranc.repo }}"
-        issue-term="{{ .Site.Params.utteranc.issueTerm }}"
-        theme="{{ default "github-light" .Site.Params.utteranc.theme }}"
-        crossorigin="anonymous"
-        async>
-  </script>
-</div>


### PR DESCRIPTION
The issue required switching the commenting system to rely on discussions instead of issues, and closing the previous issues related to comments. I've configured Giscus, which works based on discussions, disabled Utterances via configuration, and ripped out Utterances from the Hugo theme layout completely. I've also appended 'Closes ...' to the commit message to close the specified issues.

---
*PR created automatically by Jules for task [6281075456626672319](https://jules.google.com/task/6281075456626672319) started by @arran4*