### PR TITLE
Add post resolving golangci-lint go version conflicts

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -416,7 +416,6 @@
     "urlesc",
     "webmproject",
     "xerrors",
-    "yuin",
-    "golangcilint"
+    "yuin"
   ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -416,6 +416,7 @@
     "urlesc",
     "webmproject",
     "xerrors",
-    "yuin"
+    "yuin",
+    "golangcilint"
   ]
 }

--- a/content/post/2026/013-resolving-golangci-lint-go-version-conflicts/index.md
+++ b/content/post/2026/013-resolving-golangci-lint-go-version-conflicts/index.md
@@ -24,7 +24,7 @@ run golangci-lint
   Ran golangci-lint in 90ms
 ```
 
-This error usually appears when your repository's Go version outpaces the Go version used to compile the `golangci-lint` binary that the action downloaded.
+This error usually appears when your repository's Go version outpaces the Go version used to compile the `golangci-lint` binary that the action downloaded. Ensuring versions match is critical to ensure that the tools and applications are mutually compatible.
 
 When this happens, here is the six-step process to get everything back in sync and passing:
 
@@ -32,7 +32,7 @@ When this happens, here is the six-step process to get everything back in sync a
 2. **Update the GitHub Action:** Update the `golangci-lint-action` reference in your workflow to the latest version. Verify current versions against their official sources:
    - For `golangci-lint-action`, check the [official repository](https://github.com/golangci/golangci-lint-action/releases) (e.g. `v9`).
    - For Go itself, verify the latest stable release at [go.dev](https://go.dev/dl/).
-3. **Upgrade Go everywhere to match:** Ensure your GitHub Actions workflows are using a `version-file: go.mod` (or similar) strategy to keep the Go version automatically in sync with the codebase.
+3. **Upgrade Go everywhere to match:** Ensure your GitHub Actions workflows are using a `go-version-file: go.mod` strategy to keep the Go version automatically in sync with the codebase (unless you are explicitly testing a matrix of older versions).
 4. **Resolve issues iteratively:** Rerun `golangci-lint` (ensure it is the same version) in a loop to resolve issues. Do not create a new config file immediately; instead, attempt to solve all issues by fixing a couple of them in each loop until they are all resolved. Note exceptions: If the project explicitly requires an older Go version for legacy compatibility, you should pin both the Go version and the `golangci-lint` binary version to compatible older releases instead of blindly upgrading to `latest`.
 5. **Format your code:** Run `go fmt ./...`.
 6. **Submit:** Once everything is green and formatted, submit your changes.
@@ -41,7 +41,7 @@ When this happens, here is the six-step process to get everything back in sync a
 
 | Component | Example Version | Verification Source |
 |---|---|---|
-| Go Language | `1.25.0` (or `stable`) | [go.dev releases](https://go.dev/dl/) |
+| Go Language | `1.25.0` | [go.dev releases](https://go.dev/dl/) |
 | golangci-lint | `v1.64.8` | [golangci-lint releases](https://github.com/golangci/golangci-lint/releases) |
 | golangci-lint-action | `v9` | [golangci-lint-action releases](https://github.com/golangci/golangci-lint-action/releases) |
 
@@ -51,7 +51,7 @@ Here is an example snippet showing an updated workflow configuration:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/content/post/2026/013-resolving-golangci-lint-go-version-conflicts/index.md
+++ b/content/post/2026/013-resolving-golangci-lint-go-version-conflicts/index.md
@@ -28,7 +28,7 @@ This error usually appears when your repository's Go version outpaces the Go ver
 
 When this happens, here is the six-step process to get everything back in sync and passing:
 
-1. **Delete golangcilint.conf files:** Remove any existing `golangcilint.conf` (or `.golangci.yml`) files to clear the slate.
+1. **Delete golangci-lint.conf files:** Remove any existing `golangci-lint.conf` (or `.golangci.yml`) files to clear the slate.
 2. **Update the GitHub Action:** Update the `golangci-lint-action` reference in your workflow to the latest version (use external references to verify the most current version).
 3. **Upgrade Go everywhere to match:** Ensure your GitHub Actions workflows are using a `version-file: go.mod` (or similar) strategy to keep the Go version automatically in sync with the codebase.
 4. **Resolve issues iteratively:** Rerun `golangci-lint` (ensure it is the same version) in a loop to resolve issues. Do not create a new config file immediately; instead, attempt to solve all issues by fixing a couple of them in each loop until they are all resolved.

--- a/content/post/2026/013-resolving-golangci-lint-go-version-conflicts/index.md
+++ b/content/post/2026/013-resolving-golangci-lint-go-version-conflicts/index.md
@@ -28,12 +28,22 @@ This error usually appears when your repository's Go version outpaces the Go ver
 
 When this happens, here is the six-step process to get everything back in sync and passing:
 
-1. **Delete golangci-lint.conf files:** Remove any existing `golangci-lint.conf` (or `.golangci.yml`) files to clear the slate.
-2. **Update the GitHub Action:** Update the `golangci-lint-action` reference in your workflow to the latest version (use external references to verify the most current version).
+1. **Delete old configurations:** Remove any existing `golangci-lint.conf` (or `.golangci.yml`) files to clear the slate.
+2. **Update the GitHub Action:** Update the `golangci-lint-action` reference in your workflow to the latest version. Verify current versions against their official sources:
+   - For `golangci-lint-action`, check the [official repository](https://github.com/golangci/golangci-lint-action/releases) (e.g. `v9`).
+   - For Go itself, verify the latest stable release at [go.dev](https://go.dev/dl/).
 3. **Upgrade Go everywhere to match:** Ensure your GitHub Actions workflows are using a `version-file: go.mod` (or similar) strategy to keep the Go version automatically in sync with the codebase.
-4. **Resolve issues iteratively:** Rerun `golangci-lint` (ensure it is the same version) in a loop to resolve issues. Do not create a new config file immediately; instead, attempt to solve all issues by fixing a couple of them in each loop until they are all resolved.
+4. **Resolve issues iteratively:** Rerun `golangci-lint` (ensure it is the same version) in a loop to resolve issues. Do not create a new config file immediately; instead, attempt to solve all issues by fixing a couple of them in each loop until they are all resolved. Note exceptions: If the project explicitly requires an older Go version for legacy compatibility, you should pin both the Go version and the `golangci-lint` binary version to compatible older releases instead of blindly upgrading to `latest`.
 5. **Format your code:** Run `go fmt ./...`.
 6. **Submit:** Once everything is green and formatted, submit your changes.
+
+### Version Reference Table
+
+| Component | Example Version | Verification Source |
+|---|---|---|
+| Go Language | `1.25.0` (or `stable`) | [go.dev releases](https://go.dev/dl/) |
+| golangci-lint | `v1.64.8` | [golangci-lint releases](https://github.com/golangci/golangci-lint/releases) |
+| golangci-lint-action | `v9` | [golangci-lint-action releases](https://github.com/golangci/golangci-lint-action/releases) |
 
 Here is an example snippet showing an updated workflow configuration:
 

--- a/content/post/2026/013-resolving-golangci-lint-go-version-conflicts/index.md
+++ b/content/post/2026/013-resolving-golangci-lint-go-version-conflicts/index.md
@@ -1,0 +1,51 @@
+---
+title: "Resolving golangci-lint Go Version Conflicts in GitHub Actions"
+date: 2026-03-05T00:00:00+00:00
+draft: false
+tags: ["go", "golangci-lint", "github-actions", "ci", "linting", "automation"]
+categories: ["devops", "reference", "go"]
+---
+
+If you have encountered a build failure in your Go project's GitHub Actions pipeline, you might see an error output similar to this:
+
+```text
+run golangci-lint
+
+  Running [/home/runner/golangci-lint-1.64.8-linux-amd64/golangci-lint config path] in [/home/runner/work/go-pattern/go-pattern] ...
+
+  Running [/home/runner/golangci-lint-1.64.8-linux-amd64/golangci-lint run] in [/home/runner/work/go-pattern/go-pattern] ...
+
+  Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
+
+  Failed executing command with error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
+
+  Error: golangci-lint exit with code 3
+
+  Ran golangci-lint in 90ms
+```
+
+This error usually appears when your repository's Go version outpaces the Go version used to compile the `golangci-lint` binary that the action downloaded.
+
+When this happens, here is the six-step process to get everything back in sync and passing:
+
+1. **Delete golangcilint.conf files:** Remove any existing `golangcilint.conf` (or `.golangci.yml`) files to clear the slate.
+2. **Update the GitHub Action:** Update the `golangci-lint-action` reference in your workflow to the latest version (use external references to verify the most current version).
+3. **Upgrade Go everywhere to match:** Ensure your GitHub Actions workflows are using a `version-file: go.mod` (or similar) strategy to keep the Go version automatically in sync with the codebase.
+4. **Resolve issues iteratively:** Rerun `golangci-lint` (ensure it is the same version) in a loop to resolve issues. Do not create a new config file immediately; instead, attempt to solve all issues by fixing a couple of them in each loop until they are all resolved.
+5. **Format your code:** Run `go fmt ./...`.
+6. **Submit:** Once everything is green and formatted, submit your changes.
+
+Here is an example snippet showing an updated workflow configuration:
+
+```yaml
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+```
+
+By following this process, you avoid getting stuck maintaining outdated lint configurations and keep your CI workflow aligned with the latest Go tools.

--- a/content/post/2026/013-resolving-golangci-lint-go-version-conflicts/index.md
+++ b/content/post/2026/013-resolving-golangci-lint-go-version-conflicts/index.md
@@ -42,7 +42,7 @@ When this happens, here is the six-step process to get everything back in sync a
 | Component | Example Version | Verification Source |
 |---|---|---|
 | Go Language | `1.25.0` | [go.dev releases](https://go.dev/dl/) |
-| golangci-lint | `v1.64.8` | [golangci-lint releases](https://github.com/golangci/golangci-lint/releases) |
+| golangci-lint | `latest` | [golangci-lint releases](https://github.com/golangci/golangci-lint/releases) |
 | golangci-lint-action | `v9` | [golangci-lint-action releases](https://github.com/golangci/golangci-lint-action/releases) |
 
 Here is an example snippet showing an updated workflow configuration:


### PR DESCRIPTION
Adds a new reference post detailing how to resolve golangci-lint Go version conflicts in GitHub actions, as requested by the user.

---
*PR created automatically by Jules for task [12245957227021755124](https://jules.google.com/task/12245957227021755124) started by @arran4*