### PR TITLE
Add LLM project upgrade instructions post

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -416,6 +416,9 @@
     "urlesc",
     "webmproject",
     "xerrors",
-    "yuin"
+    "yuin",
+    "sqflite",
+    "timezone",
+    "xanzy"
   ]
 }

--- a/content/post/2026/014-llm-upgrade-instructions/index.md
+++ b/content/post/2026/014-llm-upgrade-instructions/index.md
@@ -32,7 +32,7 @@ When upgrading a repository, always target the latest versions of the following 
 1. **Verify External Sources**: Always check external sources for the actual latest version (e.g., checking `github.com/actions/checkout` for the checkout action). LLM memory is often outdated or wrong and frequently overwrites defaults with older versions.
 2. **Local Environment Upgrades**: Ensure that the local LLM environment version is also upgraded to match the target versions. This is crucial for local testing. If it cannot be done locally for whatever reason, utilize the CI system for testing.
 3. **Enforce Minimum Requirements**: Minimum language requirements must be updated in the project's configuration files (e.g., updating the `go` directive in `go.mod`, or the Flutter SDK version range in `pubspec.yaml`) to enforce the upgrade.
-4. **GitHub Actions Constraints**: Check GitHub actions, all constants, and versions referred to. Ensure that, if possible, CI steps are bound to the versions specified in the code. For example, use `use-version-file: go.mod` instead of hardcoding a Go version in a GitHub Action, unless a hardcoded version is required for another specific reason (like regression testing, forward compatibility testing, matrix testing, etc.).
+4. **GitHub Actions Constraints**: Check GitHub actions, all constants, and versions referred to. Ensure that, if possible, CI steps are bound to the versions specified in the code. For example, use `go-version-file: go.mod` instead of hardcoding a Go version in a GitHub Action, unless a hardcoded version is required for another specific reason (like regression testing, forward compatibility testing, matrix testing, etc.).
 
 ## Upgrade Process and Testing
 

--- a/content/post/2026/014-llm-upgrade-instructions/index.md
+++ b/content/post/2026/014-llm-upgrade-instructions/index.md
@@ -1,0 +1,100 @@
+---
+title: "LLM Instructions: Upgrading Projects"
+date: "2026-07-07T12:00:00Z"
+draft: false
+tags:
+  - llm
+  - instructions
+  - upgrades
+  - flutter
+  - go
+  - github-actions
+categories:
+  - Software Development
+  - LLM Instructions
+---
+
+This post acts as explicit instructions and rules for LLMs tasked with upgrading software projects. When applying an upgrade, you must follow these rules meticulously to ensure the project remains stable and up-to-date.
+
+## Upgrade Rules
+
+When upgrading a repository, always target the latest versions of the following technologies:
+
+1. **Flutter & Dart**: Ensure the project uses the latest stable releases.
+2. **GitHub Actions**: Upgrade all actions to their latest major versions.
+3. **Go (Golang)**: Update to the latest stable Go release.
+4. **Dependencies**: Upgrade all dependencies and `dev` dependencies where necessary.
+5. **Qt, KDE, and C++ Dependencies**: Assume the latest versions available.
+6. **Linters**: Ensure the linter is on the latest language-compatible version. Try to stick to safe defaults rather than relying heavily on custom configuration. Use configuration sparingly. **Never bypass a lint warning or error** without explicit user instruction. You are here to complete the task properly.
+
+## Important Checks During Upgrades
+
+1. **Verify External Sources**: Always check external sources for the actual latest version (e.g., checking `github.com/actions/checkout` for the checkout action). LLM memory is often outdated or wrong and frequently overwrites defaults with older versions.
+2. **Local Environment Upgrades**: Ensure that the local LLM environment version is also upgraded to match the target versions. This is crucial for local testing. If it cannot be done locally for whatever reason, utilize the CI system for testing.
+3. **Enforce Minimum Requirements**: Minimum language requirements must be updated in the project's configuration files (e.g., updating the `go` directive in `go.mod`, or the Flutter SDK version range in `pubspec.yaml`) to enforce the upgrade.
+4. **GitHub Actions Constraints**: Check GitHub actions, all constants, and versions referred to. Ensure that, if possible, CI steps are bound to the versions specified in the code. For example, use `use-version-file: go.mod` instead of hardcoding a Go version in a GitHub Action, unless a hardcoded version is required for another specific reason (like regression testing, forward compatibility testing, matrix testing, etc.).
+
+## Upgrade Process and Testing
+
+- **Blindly Upgrade and Test**: Dependencies are to be upgraded and tested for each version. Follow any upgrade roadmaps if provided by the dependency authors. Do not qualify with the user or wait for approval; assume these instructions to be true and proceed. Mistakes or nuances can be picked up during the PR review process.
+- **Use Docker**: You can use Docker to pull the latest versions of tools and dependencies for isolated testing.
+- **Compatibility and Downgrading**: Ensure that all dependencies and versions are compatible with one another. We might need to downgrade certain dependencies for version compatibility. If downgrading is necessary, pick the path of least resistance and present the options to the user before pushing. The state of the application before the upgrade is relevant; it should be better off afterwards.
+- **Increase Test Coverage**: Increase testing for assurances that things still work as they used to. Tests can be written first and should focus heavily on known hotspots affected by the upgrade. Do your research to figure out exactly what to change and update.
+
+## Current Versions Reference Table
+
+As of writing, the current latest versions of commonly used technologies based on common repositories are provided in the table below. When upgrading, check the provided locations to fetch the *actual* latest versions.
+
+### Core Languages & Frameworks
+
+| Technology | Current Version (As of Writing) | Location to Check for Latest |
+|---|---|---|
+| **Go** | `1.26.5` | [https://go.dev/VERSION?m=text](https://go.dev/VERSION?m=text) |
+| **Flutter** | `3.44.5` | [Flutter Linux Releases JSON](https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json) |
+| **Dart** | `3.12.2` | Checked via the Flutter releases JSON |
+
+### GitHub Actions
+
+| Action | Current Version | Location to Check |
+|---|---|---|
+| **actions/checkout** | `v7.0.0` | [github.com/actions/checkout](https://github.com/actions/checkout/releases/latest) |
+| **actions/setup-go** | `v6.5.0` | [github.com/actions/setup-go](https://github.com/actions/setup-go/releases/latest) |
+| **subosito/flutter-action** | `v2.23.0` | [github.com/subosito/flutter-action](https://github.com/subosito/flutter-action/releases/latest) |
+| **golangci/golangci-lint-action** | `v9.3.0` | [github.com/golangci/golangci-lint-action](https://github.com/golangci/golangci-lint-action/releases/latest) |
+| **goreleaser/goreleaser-action** | `v7.2.3` | [github.com/goreleaser/goreleaser-action](https://github.com/goreleaser/goreleaser-action/releases/latest) |
+| **softprops/action-gh-release** | `v3.0.1` | [github.com/softprops/action-gh-release](https://github.com/softprops/action-gh-release/releases/latest) |
+| **arran4/git-tag-inc-action** | `v1.1` | [github.com/arran4/git-tag-inc-action](https://github.com/arran4/git-tag-inc-action/releases/latest) |
+| **peter-evans/create-pull-request** | `v8.1.1` | [github.com/peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request/releases/latest) |
+| **actions/download-artifact** | `v8.0.1` | [github.com/actions/download-artifact](https://github.com/actions/download-artifact/releases/latest) |
+
+### Common Go Dependencies
+
+| Dependency | Current Version | Location to Check |
+|---|---|---|
+| **golang.org/x/net** | `v0.56.0` | [proxy.golang.org](https://proxy.golang.org/golang.org/x/net/@latest) |
+| **golang.org/x/sys** | `v0.46.0` | [proxy.golang.org](https://proxy.golang.org/golang.org/x/sys/@latest) |
+| **golang.org/x/image** | `v0.43.0` | [proxy.golang.org](https://proxy.golang.org/golang.org/x/image/@latest) |
+| **golang.org/x/crypto** | `v0.53.0` | [proxy.golang.org](https://proxy.golang.org/golang.org/x/crypto/@latest) |
+| **golang.org/x/tools** | `v0.47.0` | [proxy.golang.org](https://proxy.golang.org/golang.org/x/tools/@latest) |
+| **golang.org/x/text** | `v0.39.0` | [proxy.golang.org](https://proxy.golang.org/golang.org/x/text/@latest) |
+| **github.com/google/go-cmp** | `v0.7.0` | [proxy.golang.org](https://proxy.golang.org/github.com/google/go-cmp/@latest) |
+| **github.com/xanzy/ssh-agent** | `v0.3.3` | [proxy.golang.org](https://proxy.golang.org/github.com/xanzy/ssh-agent/@latest) |
+
+### Common Dart/Flutter Dependencies
+
+| Dependency | Current Version | Location to Check |
+|---|---|---|
+| **cupertino_icons** | `1.0.9` | [pub.dev](https://pub.dev/packages/cupertino_icons) |
+| **xdg_directories** | `1.1.0` | [pub.dev](https://pub.dev/packages/xdg_directories) |
+| **toml** | `0.18.0` | [pub.dev](https://pub.dev/packages/toml) |
+| **timezone** | `0.11.1` | [pub.dev](https://pub.dev/packages/timezone) |
+| **sqflite_common_ffi_web** | `1.1.2` | [pub.dev](https://pub.dev/packages/sqflite_common_ffi_web) |
+| **sqflite_common_ffi** | `2.4.2` | [pub.dev](https://pub.dev/packages/sqflite_common_ffi) |
+| **sqflite** | `2.4.3` | [pub.dev](https://pub.dev/packages/sqflite) |
+| **settings_ui** | `3.0.1` | [pub.dev](https://pub.dev/packages/settings_ui) |
+
+### Other Dependencies
+
+| Technology | Current Version (As of Writing) | Location to Check for Latest |
+|---|---|---|
+| **Qt / KDE / C++ deps** | Assume Latest | Respective official project websites |


### PR DESCRIPTION
Added a new blog post providing explicit instructions and rules for LLMs tasked with upgrading software projects, including testing, requirements, linting rules, and a reference table for the latest versions of common technologies and dependencies.

---
*PR created automatically by Jules for task [11341938388326926834](https://jules.google.com/task/11341938388326926834) started by @arran4*