### PR TITLE
Add LLM Instructions for golangci-lint mismatches

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -420,7 +420,6 @@
     "sqflite",
     "timezone",
     "xanzy",
-    "golangcilint",
     "repoless",
     "mdtohtml"
   ]

--- a/.cspell.json
+++ b/.cspell.json
@@ -419,6 +419,9 @@
     "yuin",
     "sqflite",
     "timezone",
-    "xanzy"
+    "xanzy",
+    "golangcilint",
+    "repoless",
+    "mdtohtml"
   ]
 }

--- a/content/post/2026/015-llm-instructions-golangci-lint-version-conflicts/index.md
+++ b/content/post/2026/015-llm-instructions-golangci-lint-version-conflicts/index.md
@@ -1,0 +1,57 @@
+---
+title: "LLM Instructions: Fixing golangci-lint Go Version Mismatches"
+date: "2026-07-08T02:00:00Z"
+draft: false
+tags:
+  - llm
+  - instructions
+  - golangci-lint
+  - go
+  - github-actions
+categories:
+  - LLM Instructions
+  - DevOps
+---
+
+This post serves as explicit instructions for LLM agents (like Jules) on how to correctly handle and resolve `golangci-lint` Go version mismatch errors without requiring the user to repeatedly copy-paste the same workflow.
+
+If you encounter an error like the following during a build or lint process:
+
+```text
+run golangci-lint
+  Running [/home/runner/golangci-lint-1.64.8-linux-amd64/golangci-lint config path] in [/home/runner/work/fork-mdtohtml/fork-mdtohtml] ...
+  Running [/home/runner/golangci-lint-1.64.8-linux-amd64/golangci-lint run] in [/home/runner/work/fork-mdtohtml/fork-mdtohtml] ...
+  Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
+  Failed executing command with error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
+
+  Error: golangci-lint exit with code 3
+  Ran golangci-lint in 85ms
+```
+
+Do not fallback to old, incompatible versions of Go, `golangci-lint`, or `golangci-lint-action`.
+
+When you see this error, it means you must follow these exact steps to resolve the issue:
+
+1. **Delete Config Files**: Delete any existing `golangcilint.conf` (or `.golangci.yml` / `.golangci.yaml`) files.
+2. **Update the Action**: Update `golangci-lint` and `golangci-lint-action` to the latest versions. Rely on external references (e.g., checking GitHub releases) rather than outdated default knowledge.
+3. **Upgrade Go Everywhere**: Upgrade Go across the entire repository to match the targeted version. Ensure that GitHub Actions workflows are using a `go-version-file: go.mod` (or similar) strategy to keep the Go version automatically in sync.
+4. **Resolve Issues in a Loop**: Rerun `golangci-lint` (ensuring it is the same upgraded version) in a loop to resolve any issues. **Do not create a new config file.** Attempt to solve all issues iteratively (a couple each loop) until it runs cleanly and all issues are resolved.
+5. **Format the Code**: Run `go fmt ./...`.
+6. **Submit**: Once everything passes and is formatted correctly, submit the changes.
+
+### Example GitHub Action Configuration
+
+Here is an example of the correct, modernized GitHub Actions workflow configuration you should aim for:
+
+```yaml
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+```
+
+**LLM Directive:** Do not default to old versions. Adhere strictly to this repoless explanation whenever you are asked to resolve `golangci-lint` Go version mismatches.

--- a/content/post/2026/015-llm-instructions-golangci-lint-version-conflicts/index.md
+++ b/content/post/2026/015-llm-instructions-golangci-lint-version-conflicts/index.md
@@ -32,8 +32,8 @@ Do not fallback to old, incompatible versions of Go, `golangci-lint`, or `golang
 
 When you see this error, it means you must follow these exact steps to resolve the issue:
 
-1. **Delete Config Files**: Delete any existing `golangcilint.conf` (or `.golangci.yml` / `.golangci.yaml`) files.
-2. **Update the Action**: Update `golangci-lint` and `golangci-lint-action` to the latest versions. Rely on external references (e.g., checking GitHub releases) rather than outdated default knowledge.
+1. **Delete Config Files**: Delete any existing `golangci-lint.conf` (or `.golangci.yml` / `.golangci.yaml`) files.
+2. **Update the Action**: Update `golangci-lint` and `golangci-lint-action` to the latest versions. Rely on external references (e.g., checking GitHub releases) rather than outdated default knowledge. When doing so, use the major version tag (e.g., `v9`) rather than strict patch version pinning (like `v9.3.4`), and prefer `latest` where appropriate to avoid contradictions with general LLM upgrade instructions. See the [LLM Upgrade Instructions](/blog/post/2026/014-llm-upgrade-instructions/) for more general guidance on upgrades.
 3. **Upgrade Go Everywhere**: Upgrade Go across the entire repository to match the targeted version. Ensure that GitHub Actions workflows are using a `go-version-file: go.mod` (or similar) strategy to keep the Go version automatically in sync.
 4. **Resolve Issues in a Loop**: Rerun `golangci-lint` (ensuring it is the same upgraded version) in a loop to resolve any issues. **Do not create a new config file.** Attempt to solve all issues iteratively (a couple each loop) until it runs cleanly and all issues are resolved.
 5. **Format the Code**: Run `go fmt ./...`.


### PR DESCRIPTION
Adds a new post explaining the resolution process for golangci-lint version conflicts, including adding new technical terms to `.cspell.json`.

---
*PR created automatically by Jules for task [4070213835868900714](https://jules.google.com/task/4070213835868900714) started by @arran4*