### PR TITLE
Add GitHub Actions workflow to check for blog post number collisions

### DIFF
--- a/.github/scripts/check_post_numbers.py
+++ b/.github/scripts/check_post_numbers.py
@@ -30,19 +30,6 @@ def get_local_posts():
 
     return posts
 
-def check_local_collisions(local_posts):
-    collision_found = False
-    for year, posts in local_posts.items():
-        seen = defaultdict(list)
-        for number, folder in posts:
-            seen[number].append(folder)
-
-        for number, folders in seen.items():
-            if len(folders) > 1:
-                print(f"Error: Local collision detected in year {year} for number {number}. Folders: {', '.join(folders)}")
-                collision_found = True
-    return collision_found
-
 def get_pr_files(repo, pr_number, token):
     url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files?per_page=100"
     req = urllib.request.Request(url)
@@ -78,10 +65,23 @@ def get_open_prs(repo, token):
     req.add_header('Accept', 'application/vnd.github.v3+json')
     req.add_header('User-Agent', 'check-post-numbers-script')
 
+    prs = []
+    page = 1
     try:
-        with urllib.request.urlopen(req) as response:
-            data = json.loads(response.read().decode())
-            return [pr['number'] for pr in data]
+        while True:
+            paginated_url = f"{url}&page={page}"
+            req = urllib.request.Request(paginated_url)
+            req.add_header('Authorization', f'token {token}')
+            req.add_header('Accept', 'application/vnd.github.v3+json')
+            req.add_header('User-Agent', 'check-post-numbers-script')
+
+            with urllib.request.urlopen(req) as response:
+                data = json.loads(response.read().decode())
+                if not data:
+                    break
+                prs.extend([pr['number'] for pr in data])
+                page += 1
+        return prs
     except Exception as e:
         print(f"Failed to fetch open PRs: {e}")
         return []
@@ -99,14 +99,6 @@ def extract_post_info_from_path(path):
     return None, None, None
 
 def main():
-    # 1. Check local collisions (handles main branch and this PR's own conflicts)
-    local_posts = get_local_posts()
-    local_collision = check_local_collisions(local_posts)
-
-    if local_collision:
-        print("Local collisions found. Exiting with error.")
-        sys.exit(1)
-
     repo = os.environ.get('GITHUB_REPOSITORY')
     token = os.environ.get('GITHUB_TOKEN')
 
@@ -124,19 +116,40 @@ def main():
 
     print(f"Current PR: {current_pr}")
 
-    # 2. Get files changed in current PR
+    # 1. Get files changed in current PR
     current_pr_files = get_pr_files(repo, current_pr, token)
     current_pr_posts = {} # (year, number) -> folder
+    current_pr_folders = set()
     for f in current_pr_files:
         year, number, folder = extract_post_info_from_path(f)
         if year and number:
             current_pr_posts[(year, number)] = folder
+            current_pr_folders.add(folder)
 
     if not current_pr_posts:
         print("No new/modified posts in this PR. Success.")
         sys.exit(0)
 
     print(f"Posts modified in this PR: {current_pr_posts}")
+
+    # 2. Check local collisions, but only fail if they involve folders modified in this PR
+    local_posts = get_local_posts()
+    local_collision_found = False
+    for year, posts in local_posts.items():
+        seen = defaultdict(list)
+        for number, folder in posts:
+            seen[number].append(folder)
+
+        for number, folders in seen.items():
+            if len(folders) > 1:
+                # Only care if this PR actually touched one of the colliding folders
+                if any(f in current_pr_folders for f in folders):
+                    print(f"Error: Local collision detected in year {year} for number {number}. Folders: {', '.join(folders)} (involves current PR)")
+                    local_collision_found = True
+
+    if local_collision_found:
+        print("Local collisions involving PR found. Exiting with error.")
+        sys.exit(1)
 
     # 3. Check against open PRs with lower numbers
     open_prs = get_open_prs(repo, token)

--- a/.github/scripts/check_post_numbers.py
+++ b/.github/scripts/check_post_numbers.py
@@ -1,0 +1,167 @@
+import os
+import re
+import sys
+import json
+import urllib.request
+from collections import defaultdict
+
+def get_local_posts():
+    """Returns a dict of year -> list of (number, folder_name)"""
+    posts = defaultdict(list)
+    base_dir = "content/post"
+    if not os.path.exists(base_dir):
+        return posts
+
+    for year in os.listdir(base_dir):
+        year_path = os.path.join(base_dir, year)
+        if not os.path.isdir(year_path) or not year.isdigit():
+            continue
+
+        for post in os.listdir(year_path):
+            post_path = os.path.join(year_path, post)
+            if not os.path.isdir(post_path):
+                continue
+
+            # Extract number from start of folder name, e.g., "001-Type-Switched-Variadic-System"
+            match = re.match(r'^(\d+)-', post)
+            if match:
+                number = match.group(1)
+                posts[year].append((number, post))
+
+    return posts
+
+def check_local_collisions(local_posts):
+    collision_found = False
+    for year, posts in local_posts.items():
+        seen = defaultdict(list)
+        for number, folder in posts:
+            seen[number].append(folder)
+
+        for number, folders in seen.items():
+            if len(folders) > 1:
+                print(f"Error: Local collision detected in year {year} for number {number}. Folders: {', '.join(folders)}")
+                collision_found = True
+    return collision_found
+
+def get_pr_files(repo, pr_number, token):
+    url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files?per_page=100"
+    req = urllib.request.Request(url)
+    req.add_header('Authorization', f'token {token}')
+    req.add_header('Accept', 'application/vnd.github.v3+json')
+    req.add_header('User-Agent', 'check-post-numbers-script')
+
+    files = []
+    page = 1
+    try:
+        while True:
+            paginated_url = f"{url}&page={page}"
+            req = urllib.request.Request(paginated_url)
+            req.add_header('Authorization', f'token {token}')
+            req.add_header('Accept', 'application/vnd.github.v3+json')
+            req.add_header('User-Agent', 'check-post-numbers-script')
+
+            with urllib.request.urlopen(req) as response:
+                data = json.loads(response.read().decode())
+                if not data:
+                    break
+                files.extend([f['filename'] for f in data])
+                page += 1
+        return files
+    except Exception as e:
+        print(f"Failed to fetch files for PR {pr_number}: {e}")
+        return []
+
+def get_open_prs(repo, token):
+    url = f"https://api.github.com/repos/{repo}/pulls?state=open&per_page=100"
+    req = urllib.request.Request(url)
+    req.add_header('Authorization', f'token {token}')
+    req.add_header('Accept', 'application/vnd.github.v3+json')
+    req.add_header('User-Agent', 'check-post-numbers-script')
+
+    try:
+        with urllib.request.urlopen(req) as response:
+            data = json.loads(response.read().decode())
+            return [pr['number'] for pr in data]
+    except Exception as e:
+        print(f"Failed to fetch open PRs: {e}")
+        return []
+
+def extract_post_info_from_path(path):
+    # content/post/2026/011-simplified-github-ci/...
+    parts = path.split('/')
+    if len(parts) >= 4 and parts[0] == 'content' and parts[1] == 'post':
+        year = parts[2]
+        folder = parts[3]
+        if year.isdigit():
+            match = re.match(r'^(\d+)-', folder)
+            if match:
+                return year, match.group(1), folder
+    return None, None, None
+
+def main():
+    # 1. Check local collisions (handles main branch and this PR's own conflicts)
+    local_posts = get_local_posts()
+    local_collision = check_local_collisions(local_posts)
+
+    if local_collision:
+        print("Local collisions found. Exiting with error.")
+        sys.exit(1)
+
+    repo = os.environ.get('GITHUB_REPOSITORY')
+    token = os.environ.get('GITHUB_TOKEN')
+
+    event_path = os.environ.get('GITHUB_EVENT_PATH')
+    current_pr = None
+    if event_path and os.path.exists(event_path):
+        with open(event_path, 'r') as f:
+            event_data = json.load(f)
+            if 'pull_request' in event_data:
+                current_pr = event_data['pull_request']['number']
+
+    if not repo or not token or not current_pr:
+        print("Not running in a PR context or missing token/repo. Success for non-PR build.")
+        sys.exit(0)
+
+    print(f"Current PR: {current_pr}")
+
+    # 2. Get files changed in current PR
+    current_pr_files = get_pr_files(repo, current_pr, token)
+    current_pr_posts = {} # (year, number) -> folder
+    for f in current_pr_files:
+        year, number, folder = extract_post_info_from_path(f)
+        if year and number:
+            current_pr_posts[(year, number)] = folder
+
+    if not current_pr_posts:
+        print("No new/modified posts in this PR. Success.")
+        sys.exit(0)
+
+    print(f"Posts modified in this PR: {current_pr_posts}")
+
+    # 3. Check against open PRs with lower numbers
+    open_prs = get_open_prs(repo, token)
+    lower_prs = [pr for pr in open_prs if pr < current_pr]
+
+    print(f"Checking against lower priority PRs (lower PR numbers): {lower_prs}")
+
+    conflict_found = False
+    for pr in lower_prs:
+        pr_files = get_pr_files(repo, pr, token)
+        for f in pr_files:
+            year, number, folder = extract_post_info_from_path(f)
+            if year and number:
+                if (year, number) in current_pr_posts:
+                    current_folder = current_pr_posts[(year, number)]
+                    if current_folder != folder:
+                        print(f"Error: Collision detected! Current PR {current_pr} uses {year}/{number} for '{current_folder}', but lower priority PR {pr} uses it for '{folder}'.")
+                        conflict_found = True
+
+    if conflict_found:
+        print("PR collisions found. Exiting with error.")
+        sys.exit(1)
+
+    print("No collisions found. Success.")
+    sys.exit(0)
+
+if __name__ == '__main__':
+    main()

--- a/.github/scripts/check_post_numbers.py
+++ b/.github/scripts/check_post_numbers.py
@@ -25,18 +25,13 @@ def get_local_posts():
             # Extract number from start of folder name, e.g., "001-Type-Switched-Variadic-System"
             match = re.match(r'^(\d+)-', post)
             if match:
-                number = match.group(1)
+                number = int(match.group(1))
                 posts[year].append((number, post))
 
     return posts
 
 def get_pr_files(repo, pr_number, token):
     url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files?per_page=100"
-    req = urllib.request.Request(url)
-    req.add_header('Authorization', f'token {token}')
-    req.add_header('Accept', 'application/vnd.github.v3+json')
-    req.add_header('User-Agent', 'check-post-numbers-script')
-
     files = []
     page = 1
     try:
@@ -60,11 +55,6 @@ def get_pr_files(repo, pr_number, token):
 
 def get_open_prs(repo, token):
     url = f"https://api.github.com/repos/{repo}/pulls?state=open&per_page=100"
-    req = urllib.request.Request(url)
-    req.add_header('Authorization', f'token {token}')
-    req.add_header('Accept', 'application/vnd.github.v3+json')
-    req.add_header('User-Agent', 'check-post-numbers-script')
-
     prs = []
     page = 1
     try:
@@ -95,7 +85,7 @@ def extract_post_info_from_path(path):
         if year.isdigit():
             match = re.match(r'^(\d+)-', folder)
             if match:
-                return year, match.group(1), folder
+                return year, int(match.group(1)), folder
     return None, None, None
 
 def main():
@@ -122,7 +112,7 @@ def main():
     current_pr_folders = set()
     for f in current_pr_files:
         year, number, folder = extract_post_info_from_path(f)
-        if year and number:
+        if year is not None and number is not None:
             current_pr_posts[(year, number)] = folder
             current_pr_folders.add(folder)
 
@@ -162,7 +152,7 @@ def main():
         pr_files = get_pr_files(repo, pr, token)
         for f in pr_files:
             year, number, folder = extract_post_info_from_path(f)
-            if year and number:
+            if year is not None and number is not None:
                 if (year, number) in current_pr_posts:
                     current_folder = current_pr_posts[(year, number)]
                     if current_folder != folder:

--- a/.github/workflows/check-post-numbers.yml
+++ b/.github/workflows/check-post-numbers.yml
@@ -1,0 +1,22 @@
+name: Check Post Numbers
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-numbers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Run check_post_numbers.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 .github/scripts/check_post_numbers.py

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 /.idea
 *.iml
 /.hugo_build.lock
-.pyc
+*.pyc
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.idea
 *.iml
 /.hugo_build.lock
+.pyc
+__pycache__


### PR DESCRIPTION
This adds a new GitHub workflow and Python script to check for duplicate blog post numbers in the repository.

Features:
- Checks the local main/master content for duplicate numbers in the same year.
- Fetches the files in the current PR using the GitHub API to check against.
- Queries all other open PRs with a lower PR number (higher priority).
- Will fail the action if a duplicate number is found between the current PR and an older (higher priority) PR, enforcing priority for older PRs.
- `.gitignore` was updated to ignore python pycache files.

---
*PR created automatically by Jules for task [17905924239505406831](https://jules.google.com/task/17905924239505406831) started by @arran4*