### PR TITLE
docs: update README to clarify blog usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 I guess always under development.
 
+This blog is mostly used for agent prompt templates.
+
 Found at:
 
 https://arran4.github.io/blog/


### PR DESCRIPTION
This PR updates the `README.md` to mention that the blog is mostly used for agent prompt templates, as requested by the user.

---
*PR created automatically by Jules for task [1859410062784528130](https://jules.google.com/task/1859410062784528130) started by @arran4*