### PR TITLE
Add blog post on automated monthly releases and reports

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -442,6 +442,10 @@
     "FODMAP",
     "Pandoc",
     "xelatex",
-    "EPUB"
+    "EPUB",
+    "oneline",
+    "texlive",
+    "xetex",
+    "reimplementing"
   ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -447,6 +447,7 @@
     "texlive",
     "xetex",
     "reimplementing",
-    "timeframe"
+    "timeframe",
+    "wkhtmltopdf"
   ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -438,6 +438,9 @@
     "tsquashfs",
     "dataformats",
     "myapp",
-    "RDONLY"
+    "RDONLY",
+    "FODMAP",
+    "Pandoc",
+    "xelatex"
   ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -446,6 +446,7 @@
     "oneline",
     "texlive",
     "xetex",
-    "reimplementing"
+    "reimplementing",
+    "timeframe"
   ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -441,6 +441,7 @@
     "RDONLY",
     "FODMAP",
     "Pandoc",
-    "xelatex"
+    "xelatex",
+    "EPUB"
   ]
 }

--- a/content/post/2026/021-monthly-releases-and-reports/index.md
+++ b/content/post/2026/021-monthly-releases-and-reports/index.md
@@ -1,0 +1,37 @@
+---
+title: "Automating Monthly Releases and Reports for GitHub Projects"
+date: 2026-07-11T00:00:00Z
+draft: false
+tags: ["github-actions", "automation", "reporting", "static-sites", "seo"]
+categories: ["automation", "best-practices"]
+---
+
+For "link and article" style pages, as well as data-defined content repositories, generating monthly releases is a powerful way to keep your audience engaged. People often subscribe to "releases" on GitHub pages, and providing them with an "issue" gives them tangible updates without needing to dig through commit logs.
+
+This approach helps people remember your project rather than simply starring it and forgetting it exists. While generating a summary of changes automatically can be complex depending on the project structure, creating the release artifact itself is straightforward and highly valuable.
+
+## Monthly Magazine-Style Releases
+
+One project where I apply this strategy is a "complex page of links": [Awesome FODMAP Resources](https://github.com/arran4/awesome-fodmap-resources). In its [monthly release workflow](https://github.com/arran4/awesome-fodmap-resources/blob/main/.github/workflows/monthly-release.yml), GitHub Actions builds a book and outputs an EPUB file using Pandoc. This transforms a web-centric resource into a consumable monthly "issue."
+
+Another project, [UX](https://github.com/arran4/ux), is much simpler—just a single page of links. Its [monthly release workflow](https://github.com/arran4/ux/blob/main/.github/workflows/monthly-release.yml) checks for updates from the previous month and uses `xelatex` to generate a PDF.
+
+These workflows follow a similar pattern:
+1. Check if changes occurred since the last release.
+2. If changes exist, compile the content into a readable artifact (PDF, EPUB).
+3. Create a GitHub Release attaching these artifacts.
+
+## Personal Monthly Reports and Automated READMEs
+
+Beyond public-facing content, this automation is incredible for personal metrics. In my [arran4](https://github.com/arran4/arran4) repository, I have a few examples of this:
+
+- **Monthly Reports:** The [monthly-report.yml workflow](https://github.com/arran4/arran4/blob/master/.github/workflows/monthly-report.yml) runs a Python script to generate a report and automatically creates an issue. This works particularly well for private projects, as you can schedule it to execute right when your monthly data resets. Alternatively, you can run it just before the reset to capture your final usage for the month.
+- **Automated READMEs:** The [update-readme.yml workflow](https://github.com/arran4/arran4/blob/master/.github/workflows/update-readme.yml) automatically updates a table in the repository's README and generates a Pull Request with the changes.
+
+## The Importance of SEO and Accessibility
+
+While GitHub is a fantastic platform for developers, it's important to remember that not everyone is comfortable navigating it. By generating proper websites (like Hugo static sites) alongside your repository, you achieve two things:
+1. You provide a friendlier interface for non-technical users to consume your content.
+2. You significantly improve your SEO (Search Engine Optimization), making your project discoverable through standard web searches.
+
+Combining these SEO-friendly static sites with automated monthly release artifacts ensures your content reaches the widest possible audience while keeping subscribers consistently updated.

--- a/content/post/2026/021-monthly-releases-and-reports/index.md
+++ b/content/post/2026/021-monthly-releases-and-reports/index.md
@@ -10,23 +10,83 @@ For "link and article" style pages, as well as data-defined content repositories
 
 This approach helps people remember your project rather than simply starring it and forgetting it exists. While generating a summary of changes automatically can be complex depending on the project structure, creating the release artifact itself is straightforward and highly valuable.
 
-## Monthly Magazine-Style Releases
+## The Core Components of an Automated Release
 
-One project where I apply this strategy is a "complex page of links": [Awesome FODMAP Resources](https://github.com/arran4/awesome-fodmap-resources). In its [monthly release workflow](https://github.com/arran4/awesome-fodmap-resources/blob/main/.github/workflows/monthly-release.yml), GitHub Actions builds a book and outputs an EPUB file using Pandoc. This transforms a web-centric resource into a consumable monthly "issue."
+To use this pattern effectively, you need a workflow that triggers on a schedule, determines if changes have occurred, builds the necessary artifacts, and publishes a release. Here is a breakdown of the vital components to construct a robust monthly release workflow.
 
-Another project, [UX](https://github.com/arran4/ux), is much simpler—just a single page of links. Its [monthly release workflow](https://github.com/arran4/ux/blob/main/.github/workflows/monthly-release.yml) checks for updates from the previous month and uses `xelatex` to generate a PDF.
+This acts as a reference for reimplementing these systems, whether manually or by prompting an LLM.
 
-These workflows follow a similar pattern:
-1. Check if changes occurred since the last release.
-2. If changes exist, compile the content into a readable artifact (PDF, EPUB).
-3. Create a GitHub Release attaching these artifacts.
+### 1. Scheduled Triggers
+
+The core of a monthly release is the `schedule` trigger in your GitHub Actions workflow file.
+
+```yaml
+on:
+  schedule:
+    - cron: '0 0 1 * *' # Run at midnight on the 1st of every month
+  workflow_dispatch: # Always allow manual triggers for testing
+```
+
+Using `workflow_dispatch` alongside `cron` is critical so you can debug the workflow without waiting for a month to pass.
+
+### 2. Checking for Changes
+
+You don't want to publish an empty release if no commits were made. You must use `actions/checkout` with `fetch-depth: 0` to pull down all history and tags.
+
+Then, you can calculate the changes between the last tag and `HEAD`, or between specific dates. Here is a robust way to check for updates in the previous month:
+
+```bash
+# Calculate the start and end dates of the previous month
+START_DATE=$(date -d "last month" +'%Y-%m-01')
+END_DATE=$(date +'%Y-%m-01')
+
+# Check for commits in that timeframe
+COMMITS=$(git log --since="$START_DATE" --before="$END_DATE" --oneline)
+
+if [[ -z "$COMMITS" ]]; then
+  echo "has_updates=false" >> $GITHUB_OUTPUT
+else
+  echo "has_updates=true" >> $GITHUB_OUTPUT
+  # Set version for release (e.g., 2026.07)
+  echo "VERSION=$(date -d "last month" +'%Y.%m')" >> $GITHUB_ENV
+fi
+```
+
+### 3. Compiling the Artifacts
+
+If changes exist (`if: steps.check_updates.outputs.has_updates == 'true'`), you build the artifact. This could involve Pandoc for EPUBs, `xelatex` for PDFs, or custom scripts for HTML generation.
+
+```yaml
+- name: Generate PDF
+  if: steps.check_updates.outputs.has_updates == 'true'
+  run: |
+    # Install dependencies like pandoc or texlive
+    sudo apt-get update && sudo apt-get install -y pandoc texlive-xetex
+    # Generate the document
+    pandoc README.md -o Monthly_Issue.pdf --pdf-engine=xelatex
+```
+
+### 4. Publishing the Release
+
+Finally, attach the generated files to a GitHub release. `softprops/action-gh-release` is an excellent standard action for this.
+
+```yaml
+- name: Create Release
+  if: steps.check_updates.outputs.has_updates == 'true'
+  uses: softprops/action-gh-release@v1
+  with:
+    tag_name: v${{ env.VERSION }}
+    name: Issue ${{ env.VERSION }}
+    body: "Monthly release for ${{ env.VERSION }}. Contains updates from the previous month."
+    files: Monthly_Issue.pdf
+```
 
 ## Personal Monthly Reports and Automated READMEs
 
-Beyond public-facing content, this automation is incredible for personal metrics. In my [arran4](https://github.com/arran4/arran4) repository, I have a few examples of this:
+Beyond public-facing content, this automation is incredible for personal metrics. The pattern is similar but ends in an issue or PR instead of a release:
 
-- **Monthly Reports:** The [monthly-report.yml workflow](https://github.com/arran4/arran4/blob/master/.github/workflows/monthly-report.yml) runs a Python script to generate a report and automatically creates an issue. This works particularly well for private projects, as you can schedule it to execute right when your monthly data resets. Alternatively, you can run it just before the reset to capture your final usage for the month.
-- **Automated READMEs:** The [update-readme.yml workflow](https://github.com/arran4/arran4/blob/master/.github/workflows/update-readme.yml) automatically updates a table in the repository's README and generates a Pull Request with the changes.
+- **Monthly Reports:** Run a Python script to gather your data and use the GitHub CLI (`gh issue create`) or the REST API to generate a report issue. This works well for private projects, scheduled right when your monthly data resets.
+- **Automated READMEs:** Run a script that regenerates a table in your `README.md`. Use `git diff` to detect changes, and if changes exist, use `peter-evans/create-pull-request` to automatically submit a PR.
 
 ## The Importance of SEO and Accessibility
 

--- a/content/post/2026/021-monthly-releases-and-reports/index.md
+++ b/content/post/2026/021-monthly-releases-and-reports/index.md
@@ -54,7 +54,7 @@ fi
 
 ### 3. Compiling the Artifacts
 
-If changes exist (`if: steps.check_updates.outputs.has_updates == 'true'`), you build the artifact. This could involve Pandoc for EPUBs, `xelatex` for PDFs, or custom scripts for HTML generation.
+If changes exist (`if: steps.check_updates.outputs.has_updates == 'true'`), you build the artifact. This could involve Pandoc for EPUBs, `xelatex` for PDFs, `wkhtmltopdf`, Hugo, or custom scripts for HTML/Markdown generation.
 
 ```yaml
 - name: Generate PDF
@@ -87,6 +87,10 @@ Beyond public-facing content, this automation is incredible for personal metrics
 
 - **Monthly Reports:** Run a Python script to gather your data and use the GitHub CLI (`gh issue create`) or the REST API to generate a report issue. This works well for private projects, scheduled right when your monthly data resets.
 - **Automated READMEs:** Run a script that regenerates a table in your `README.md`. Use `git diff` to detect changes, and if changes exist, use `peter-evans/create-pull-request` to automatically submit a PR.
+
+## Setting Expectations with Users
+
+When transitioning to this model, it is crucial to update your repository's documentation. The `README.md` should be updated to ask users to subscribe to updates using GitHub's **Watch -> Custom -> Releases** feature, rather than just starring the repository. This clarifies how they can actually receive the issues you are generating.
 
 ## The Importance of SEO and Accessibility
 

--- a/content/post/2026/021-monthly-releases-and-reports/index.md
+++ b/content/post/2026/021-monthly-releases-and-reports/index.md
@@ -6,7 +6,7 @@ tags: ["github-actions", "automation", "reporting", "static-sites", "seo"]
 categories: ["automation", "best-practices"]
 ---
 
-For "link and article" style pages, as well as data-defined content repositories, generating monthly releases is a powerful way to keep your audience engaged. People often subscribe to "releases" on GitHub pages, and providing them with an "issue" gives them tangible updates without needing to dig through commit logs.
+For "link and article" style pages, as well as data-defined content repositories, generating monthly releases is a powerful way to keep your audience engaged. People often subscribe to "releases" on GitHub repositories, and providing them with a magazine-style "issue" gives them tangible updates without needing to dig through commit logs.
 
 This approach helps people remember your project rather than simply starring it and forgetting it exists. While generating a summary of changes automatically can be complex depending on the project structure, creating the release artifact itself is straightforward and highly valuable.
 


### PR DESCRIPTION
This PR adds a new blog post titled "Automating Monthly Releases and Reports for GitHub Projects".

It covers:
- Generating monthly magazine-style issues (EPUB/PDF) to keep audiences engaged.
- Utilizing automation for personal metrics and README updates.
- The SEO and accessibility benefits of generating static sites alongside repositories.

The post has been checked for correct front matter, validated with `hugo` build, and spellchecked successfully.

---
*PR created automatically by Jules for task [4102600131944955060](https://jules.google.com/task/4102600131944955060) started by @arran4*