### PR TITLE
fix: use base url for 404 and logo links

### DIFF
--- a/themes/hugo-theme-jane/layouts/404.html
+++ b/themes/hugo-theme-jane/layouts/404.html
@@ -4,7 +4,7 @@
 <div class="not-found">
   <h1 class="error-emoji"></h1>
   <p class="error-text">/* 404 page not found. */</p>
-  <p class="error-link"><a href="{{ "/" | relLangURL }}">↑ Back Home ↑</a></p>
+  <p class="error-link"><a href="{{ .Site.Home.RelPermalink }}">↑ Back Home ↑</a></p>
 </div>
 <script>
   var errorEmojiContainer = document.getElementsByClassName('error-emoji')[0];

--- a/themes/hugo-theme-jane/layouts/partials/header.html
+++ b/themes/hugo-theme-jane/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <div class="logo-wrapper">
-  <a href="{{ "/" | relLangURL }}" class="logo">
+  <a href="{{ .Site.Home.RelPermalink }}" class="logo">
     {{ if .Site.Params.logoTitle }}
       {{ .Site.Params.logoTitle | safeHTML }}
     {{ else }}

--- a/themes/hugo-theme-jane/layouts/partials/slideout.html
+++ b/themes/hugo-theme-jane/layouts/partials/slideout.html
@@ -1,6 +1,6 @@
 <div id="mobile-navbar" class="mobile-navbar">
   <div class="mobile-header-logo">
-    <a href="{{ "/" | relLangURL }}" class="logo">
+    <a href="{{ .Site.Home.RelPermalink }}" class="logo">
       {{- if .Site.Params.logoTitle -}}
         {{ .Site.Params.logoTitle | safeHTML }}
       {{- else -}}


### PR DESCRIPTION
Updates the Hugo theme template links to use `.Site.Home.RelPermalink` instead of `relLangURL` so they point correctly to the site's BaseURL.

---
*PR created automatically by Jules for task [10752122157331946892](https://jules.google.com/task/10752122157331946892) started by @arran4*