### PR TITLE
Update Post Publication Dates and agents.md Instructions

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -45,3 +45,7 @@ npx cspell --config .cspell.json "README.md" "content/**/*.md"
 ```
 
 When adding new words to the custom dictionary in `.cspell.json`, ensure that the `words` array remains alphabetically sorted (case-insensitive) and does not contain duplicates.
+
+## Post Dates
+
+When creating or modifying new articles (posts) in the blog, ensure that the `date` field in the frontmatter is updated to the current date/time on every commit. Continue to update this date on each commit until the article is first merged into the blog repository (i.e. to keep the published date matching the merge date). Once an article has been merged, its `date` should not be updated further.

--- a/content/post/2022/001-first-post/index.md
+++ b/content/post/2022/001-first-post/index.md
@@ -1,6 +1,6 @@
 ---
 title: "First Post"
-date: 2022-04-22T00:00:00+10:00
+date: 2022-04-22T00:04:52+10:00
 draft: false
 tags: []
 categories: []

--- a/content/post/2022/002-synology-security-ssh/index.md
+++ b/content/post/2022/002-synology-security-ssh/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Synology Security Advisor and SSH"
-date: 2022-04-24 12:12:08+10:00
+date: 2022-04-24T12:19:14+10:00
 draft: false
 tags: ["complaints", "synology"]
 categories: ["complaints"]

--- a/content/post/2022/003-logitech-g560/index.md
+++ b/content/post/2022/003-logitech-g560/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Logitech G560"
-date: 2022-04-26 23:16:23+10:00
+date: 2022-04-26T23:16:45+10:00
 draft: false 
 tags: ["review", "complaints", "logitech"]
 categories: ["review"]

--- a/content/post/2022/004-aws-new-glue-fail/index.md
+++ b/content/post/2022/004-aws-new-glue-fail/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Aws New Glue Fail"
-date: 2022-05-09T15:25:28+10:00
+date: 2022-05-09T15:30:12+10:00
 draft: false
 tags: ["review", "complaints", "aws"]
 categories: ["complaints"]

--- a/content/post/2022/005-Synology Office Encryption/index.md
+++ b/content/post/2022/005-Synology Office Encryption/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Synology Office Encryption"
-date: 2022-05-19T11:25:18+10:00
+date: 2022-05-19T12:57:07+10:00
 draft: false
 tags: ["complaints", "bugs", "synology"]
 categories: ["bugs"]

--- a/content/post/2022/006-Akregator doesn't work on KDE's blog/index.md
+++ b/content/post/2022/006-Akregator doesn't work on KDE's blog/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Akregator Doesn't Work on KDE's Blog"
-date: 2022-06-01T23:40:45+10:00
+date: 2022-06-01T23:43:26+10:00
 draft: false
 tags: ["kde", "issues"]
 categories: ["gripes"]

--- a/content/post/2022/007-Lenovo, Ubuntu Upgrade, and the backport-iwlwifi-dkms package/index.md
+++ b/content/post/2022/007-Lenovo, Ubuntu Upgrade, and the backport-iwlwifi-dkms package/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Lenovo, Ubuntu Upgrade, and the Backport Iwlwifi Dkms Package"
-date: 2022-06-02T21:36:08+10:00
+date: 2022-06-02T21:45:02+10:00
 draft: false
 tags: ["ubuntu", "issues"]
 categories: ["tech-issue"]

--- a/content/post/2022/008-KDE and changing mouse scroll speed/index.md
+++ b/content/post/2022/008-KDE and changing mouse scroll speed/index.md
@@ -1,6 +1,6 @@
 ---
 title: "KDE and Changing Mouse Scroll Speed"
-date: 2022-06-02T22:02:12+10:00
+date: 2022-06-02T22:10:53+10:00
 draft: false
 tags: ["kde", "gripe"]
 categories: ["kde"]

--- a/content/post/2022/009-Linux, Dmesg, and issue reporting/index.md
+++ b/content/post/2022/009-Linux, Dmesg, and issue reporting/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Linux, Dmesg, and Issue Reporting"
-date: 2022-06-02T22:19:37+10:00
+date: 2022-06-02T22:26:09+10:00
 draft: false
 tags: ["issue", "gripe", "bug tracking", "linux"]
 categories: ["issue"]

--- a/content/post/2022/010-Goland refactor dialog/index.md
+++ b/content/post/2022/010-Goland refactor dialog/index.md
@@ -1,6 +1,6 @@
 ---
 title: "GoLand Refactor Dialogue"
-date: 2022-06-13T17:17:26+10:00
+date: 2022-06-13T17:19:26+10:00
 draft: false
 tags: ["goland", "should be on a bugtracker"]
 categories: ["uncategorized"]

--- a/content/post/2022/011-Git bash and WSL on Windows Terminal Preview vs IntelliJ/index.md
+++ b/content/post/2022/011-Git bash and WSL on Windows Terminal Preview vs IntelliJ/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Git Bash and WSL on Windows Terminal Preview vs IntelliJ"
-date: 2022-06-14T10:03:29+10:00
+date: 2022-06-14T10:10:52+10:00
 draft: false
 tags: ["windows", "issues", "IntelliJ", "WSL", "git"]
 categories: ["complaints"]

--- a/content/post/2022/012-Minor bug fixes - ubuntu deb file recommends error/index.md
+++ b/content/post/2022/012-Minor bug fixes - ubuntu deb file recommends error/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Minor Bug Fixes   Ubuntu Deb File Recommends Error"
-date: 2022-08-14T00:20:42+10:00
+date: 2022-08-14T00:27:28+10:00
 draft: false
 tags: ["hassle"]
 categories: ["hassle", "bug report"]

--- a/content/post/2022/013-How to prevent KDE from starting/index.md
+++ b/content/post/2022/013-How to prevent KDE from starting/index.md
@@ -1,6 +1,6 @@
 ---
 title: "How to Prevent KDE From Starting"
-date: 2022-08-14T01:11:45+10:00
+date: 2022-08-14T01:15:58+10:00
 draft: false
 tags: ["bugs"]
 categories: ["kde"]

--- a/content/post/2022/014-Synology -- How do I update the images against a tag in the docker view?/index.md
+++ b/content/post/2022/014-Synology -- How do I update the images against a tag in the docker view?/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Synology    How Do I Update the Images Against a Tag in the Docker View?"
-date: 2022-08-14T15:24:00+10:00
+date: 2022-08-14T15:25:39+10:00
 draft: false
 tags: ["annoyance"]
 categories: ["synology"]

--- a/content/post/2022/015-Tools Rosetta stone/index.md
+++ b/content/post/2022/015-Tools Rosetta stone/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Tools Rosetta Stone"
-date: 2022-08-15T22:58:36+10:00
+date: 2022-08-15T23:55:49+10:00
 draft: false
 tags: ["tools"]
 categories: ["tools"]

--- a/content/post/2022/016-Back to KDE - My Observations/index.md
+++ b/content/post/2022/016-Back to KDE - My Observations/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Back to KDE   My Observations"
-date: 2022-08-20T16:43:13+10:00
+date: 2022-08-20T17:55:04+10:00
 draft: false
 tags: ["kde"]
 categories: ["UI", "KDE"]

--- a/content/post/2022/017-Simple screen recorder/index.md
+++ b/content/post/2022/017-Simple screen recorder/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Simple Screen Recorder"
-date: 2022-08-20T18:14:16+10:00
+date: 2022-08-20T18:18:39+10:00
 draft: false
 tags: ["Tools"]
 categories: ["Complaints"]

--- a/content/post/2022/018-LastPass/index.md
+++ b/content/post/2022/018-LastPass/index.md
@@ -1,6 +1,6 @@
 ---
 title: "LastPass"
-date: 2022-08-20T18:19:19+10:00
+date: 2022-08-20T18:25:29+10:00
 draft: false
 tags: ["lastpass"]
 categories: ["UI"]

--- a/content/post/2022/019-Signal System Tray Icon why doesn't it have one?/index.md
+++ b/content/post/2022/019-Signal System Tray Icon why doesn't it have one?/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Signal System Tray Icon Why Doesn't It Have One?"
-date: 2022-08-20T18:25:58+10:00
+date: 2022-08-20T18:27:39+10:00
 draft: false
 tags: ["Signal"]
 categories: ["UI"]

--- a/content/post/2022/020-Status Bar in Browsers/index.md
+++ b/content/post/2022/020-Status Bar in Browsers/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Status Bar in Browsers"
-date: 2022-08-20T18:27:56+10:00
+date: 2022-08-20T18:33:55+10:00
 draft: false
 tags: ["rants"]
 categories: ["UI"]

--- a/content/post/2022/021-Synology cloudsync and folder listing/index.md
+++ b/content/post/2022/021-Synology cloudsync and folder listing/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Synology Cloudsync and Folder Listing"
-date: 2022-08-21T08:51:02+10:00
+date: 2022-08-21T08:52:13+10:00
 draft: false
 tags: ["synology"]
 categories: ["ui"]

--- a/content/post/2022/022-Jetbrains and SSH Config files/index.md
+++ b/content/post/2022/022-Jetbrains and SSH Config files/index.md
@@ -1,6 +1,6 @@
 ---
 title: "JetBrains and SSH Config Files"
-date: 2022-09-25T13:39:00+10:00
+date: 2022-09-25T14:03:15+10:00
 draft: false
 tags: ["complaints"]
 categories: ["complaints"]

--- a/content/post/2022/023-Growing Synology Wish list/index.md
+++ b/content/post/2022/023-Growing Synology Wish list/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Growing Synology Wish List"
-date: 2022-09-25T14:17:40+10:00
+date: 2022-09-25T15:39:05+10:00
 draft: false
 tags: ["wish list"]
 categories: ["wish list", "synology"]

--- a/content/post/2022/024-Gmail and keyboard navigation/index.md
+++ b/content/post/2022/024-Gmail and keyboard navigation/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Gmail and Keyboard Navigation"
-date: 2022-10-01T14:14:03+10:00
+date: 2022-10-01T14:17:58+10:00
 draft: false
 tags: ["suggestions", "gmail", "keyboard"]
 categories: ["suggestions"]

--- a/content/post/2022/025-Synology mail reports caught by synology spam detector -- why/index.md
+++ b/content/post/2022/025-Synology mail reports caught by synology spam detector -- why/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Synology Mail Reports Caught by Synology Spam Detector -- Why!?"
-date: 2022-11-04T08:48:53+11:00
+date: 2022-11-04T08:52:41+11:00
 draft: false
 tags: ["synology"]
 categories: ["bugs"]

--- a/content/post/2022/026-Synology Active Insight pro plans/index.md
+++ b/content/post/2022/026-Synology Active Insight pro plans/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Synology Active Insight Pro Plans"
-date: 2022-11-04T09:31:39+11:00
+date: 2022-11-04T09:34:03+11:00
 draft: false
 tags: ["opinion"]
 categories: ["synology"]

--- a/content/post/2023/001-Synology Package Manager/index.md
+++ b/content/post/2023/001-Synology Package Manager/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Synology and UI text: The Package Manager"
-date: 2023-02-15T09:38:26+11:00
+date: 2023-02-15T09:53:49+11:00
 draft: false
 tags: ["complaint", "synology"]
 categories: ["synology"]

--- a/content/post/2023/002-KDE Discover/index.md
+++ b/content/post/2023/002-KDE Discover/index.md
@@ -1,6 +1,6 @@
 ---
 title: "KDE Discover"
-date: 2023-02-15T10:57:05+11:00
+date: 2023-02-15T11:03:28+11:00
 draft: false
 tags: ["KDE", "complaint"]
 categories: ["KDE"]

--- a/content/post/2023/003-My blogs layout and styles/index.md
+++ b/content/post/2023/003-My blogs layout and styles/index.md
@@ -1,6 +1,6 @@
 ---
 title: "My Blogs Layout and Styles"
-date: 2023-03-07T00:14:08+11:00
+date: 2023-03-07T00:14:40+11:00
 draft: false
 tags: ["untagged"]
 categories: ["uncategorized"]

--- a/content/post/2023/004-Ubuntu and Pip3/index.md
+++ b/content/post/2023/004-Ubuntu and Pip3/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Ubuntu and Pip3"
-date: 2023-05-28T21:52:36+10:00
+date: 2023-05-28T21:55:00+10:00
 draft: false
 tags: ["untagged"]
 categories: ["uncategorized"]

--- a/content/post/2023/005-golangci-lint thoughts/index.md
+++ b/content/post/2023/005-golangci-lint thoughts/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Golangci Lint Thoughts"
-date: 2023-07-23T11:18:29+10:00
+date: 2023-07-23T13:40:45+10:00
 draft: false
 tags: ["golang"]
 categories: ["thoughts", "programming"]

--- a/content/post/2024/001-Beeper/index.md
+++ b/content/post/2024/001-Beeper/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Beeper"
-date: 2024-05-31T11:07:34+10:00
+date: 2024-05-31T14:11:38+10:00
 draft: false
 tags: ["beeper"]
 categories: ["complaints"]

--- a/content/post/2024/002-Synology Chat and Open Standards/index.md
+++ b/content/post/2024/002-Synology Chat and Open Standards/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Synology Chat and Open Standards"
-date: 2024-06-18T13:11:41+10:00
+date: 2024-06-18T13:14:04+10:00
 draft: false
 tags: ["untagged"]
 categories: ["uncategorized"]

--- a/content/post/2025/001-Deploying Sieve with JMAP/index.md
+++ b/content/post/2025/001-Deploying Sieve with JMAP/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploying Sieve with JMAP"
-date: 2025-06-08T17:05:00+10:00
+date: 2025-06-08T17:13:23+10:00
 draft: false
 tags: ["sieve", "jmap", "stalwart"]
 categories: ["tutorial"]

--- a/content/post/2025/002-Sieve Workflow Fix/index.md
+++ b/content/post/2025/002-Sieve Workflow Fix/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Update to Sieve Deployment Workflow"
-date: 2025-06-09T10:00:00+10:00
+date: 2025-06-13T23:54:19+10:00
 draft: false
 tags: ["sieve", "jmap", "stalwart"]
 categories: ["tutorial"]

--- a/content/post/2025/003-Automated Sieve Testing/index.md
+++ b/content/post/2025/003-Automated Sieve Testing/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Automated Sieve Testing with Cargo"
-date: 2025-06-18T12:25:48+10:00
+date: 2025-06-18T13:36:23+10:00
 draft: false
 tags: ["sieve", "rust", "testing"]
 categories: ["tutorial"]

--- a/content/post/2025/004-Running-Multiple-Self-Hosted-Runners/index.md
+++ b/content/post/2025/004-Running-Multiple-Self-Hosted-Runners/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Running Multiple Self-Hosted GitHub Actions Runners in a Single Docker-in-Docker Container"
-date: 2025-07-05T00:00:00+10:00
+date: 2025-07-06T09:46:47+10:00
 draft: false
 tags: ["github-actions", "docker", "devops"]
 categories: ["devops"]

--- a/content/post/2025/005-Runner-Docker-Permissions-Fix/index.md
+++ b/content/post/2025/005-Runner-Docker-Permissions-Fix/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Fixing Docker Permissions in the Self-Hosted Runner Image"
-date: 2025-07-08T15:00:00+10:00
+date: 2025-07-08T20:26:26+10:00
 draft: false
 tags: ["github-actions", "docker", "devops"]
 categories: ["devops"]

--- a/content/post/2025/006-BTOP-running-in-various-terminals/index.md
+++ b/content/post/2025/006-BTOP-running-in-various-terminals/index.md
@@ -1,6 +1,6 @@
 ---
 title: "BTOP Running in Various Terminals"
-date: 2025-07-16T17:20:25+10:00
+date: 2025-07-16T18:25:09+10:00
 draft: false
 tags: ["btop", "linux", "terminals"]
 categories: ["tools"]

--- a/content/post/2025/007-Imagining-a-JavaScript-less-SPA-World/index.md
+++ b/content/post/2025/007-Imagining-a-JavaScript-less-SPA-World/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Imagining a JavaScript-less SPA World"
-date: 2025-07-17T12:00:00+10:00
+date: 2025-07-21T10:25:01+10:00
 draft: false
 tags: ["javascript", "webdev", "standards"]
 categories: ["notes"]

--- a/content/post/2025/008-Keeping-Track-of-Facebook-Friends/index.md
+++ b/content/post/2025/008-Keeping-Track-of-Facebook-Friends/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Keeping Track of Friends on Facebook When Their Accounts Keep Disappearing"
-date: 2025-07-21T12:00:00+10:00
+date: 2025-10-13T14:57:33+11:00
 draft: false
 tags: ["facebook", "automation", "personal-process"]
 categories: ["notes"]

--- a/content/post/2026/001-Git-Reference-Grammar/index.md
+++ b/content/post/2026/001-Git-Reference-Grammar/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Git Refs and Refspecs: Grammar Reference"
-date: 2026-01-05T23:59:52+00:00
+date: 2026-01-06T12:20:32+11:00
 draft: false
 tags: ["git", "refspec", "references"]
 categories: ["reference"]

--- a/content/post/2026/001-Type-Switched-Variadic-System/index.md
+++ b/content/post/2026/001-Type-Switched-Variadic-System/index.md
@@ -1,6 +1,6 @@
 ---
 title: "The Type-Switched Variadic System I Keep Reusing in Go"
-date: 2026-02-16T10:00:00+10:00
+date: 2026-02-18T15:44:02+11:00
 draft: false
 tags: ["go", "api-design", "options-pattern", "ergonomics"]
 categories: ["notes"]

--- a/content/post/2026/002-golangci-lint-action-go-version-matrix/index.md
+++ b/content/post/2026/002-golangci-lint-action-go-version-matrix/index.md
@@ -1,6 +1,6 @@
 ---
 title: "GitHub Actions + golangci-lint: Go Version Compatibility Matrix (with Copy/Paste Workflows)"
-date: 2026-02-14T00:00:00+00:00
+date: 2026-02-18T18:55:04+11:00
 draft: false
 tags: ["go", "golangci-lint", "github-actions", "ci", "linting"]
 categories: ["reference", "devops"]

--- a/content/post/2026/004-Txtar-Patterns-for-Agents/index.md
+++ b/content/post/2026/004-Txtar-Patterns-for-Agents/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Txtar Test Systems in Practice: Data, Scenarios, and Embedded Walkers"
-date: 2026-02-16T00:00:00+00:00
+date: 2026-02-18T19:00:01+11:00
 draft: false
 tags: ["go", "testing", "txtar", "embed", "golden-files", "agents"]
 categories: ["reference", "testing"]

--- a/content/post/2026/005-Template-Driven-CLI-Help-Process/index.md
+++ b/content/post/2026/005-Template-Driven-CLI-Help-Process/index.md
@@ -1,6 +1,6 @@
 ---
 title: "From Patch to Playbook: A Repeatable Process for Refactoring CLI Help Text"
-date: 2026-02-27T00:00:00+00:00
+date: 2026-02-27T14:12:39+11:00
 draft: false
 tags: ["go", "cli", "templates", "process", "agents"]
 categories: ["reference", "engineering-process"]

--- a/content/post/2026/006-github-ci-and-deploy/index.md
+++ b/content/post/2026/006-github-ci-and-deploy/index.md
@@ -1,6 +1,6 @@
 ---
 title: "The Ultimate Single GitHub Actions CI/CD File: Go, Node, Flutter, Dart, Qt/C++, Docker, and Packaging"
-date: 2026-03-04T00:00:00+00:00
+date: 2026-05-31T22:07:22+10:00
 draft: false
 tags: ["github-actions", "ci", "cd", "go", "node", "dart", "flutter", "qt", "c++", "docker", "goreleaser", "packaging"]
 categories: ["devops", "reference", "automation"]

--- a/content/post/2026/007-Go-FSs-Everywhere/index.md
+++ b/content/post/2026/007-Go-FSs-Everywhere/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Go FSs Everywhere: Treat Side Effects as Dependencies"
-date: 2026-03-08T00:00:00+00:00
+date: 2026-03-26T10:57:11+11:00
 draft: false
 tags: ["go", "testing", "architecture", "patterns"]
 categories: ["engineering-process", "reference"]

--- a/content/post/2026/008-Memory-FS-for-Testing/index.md
+++ b/content/post/2026/008-Memory-FS-for-Testing/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Go Memory FSs Everywhere in Test: Treat Side Effects as Dependencies"
-date: 2026-03-08T00:00:00+00:00
+date: 2026-04-02T16:59:23+11:00
 draft: false
 tags: ["go", "testing", "architecture", "patterns", "memory-fs"]
 categories: ["engineering-process", "reference"]

--- a/content/post/2026/009-Forensic-Recovery-of-Lost-Tabs/index.md
+++ b/content/post/2026/009-Forensic-Recovery-of-Lost-Tabs/index.md
@@ -1,6 +1,6 @@
 ---
 title: "When Firefox Fails You: Forensic Recovery of Lost Tabs on Linux"
-date: 2026-04-06T01:03:38+00:00
+date: 2026-04-06T12:28:25+10:00
 draft: false
 tags: ["linux", "firefox", "recovery", "jsonlz4", "python"]
 categories: ["tutorial", "forensics"]

--- a/content/post/2026/011-simplified-github-ci/index.md
+++ b/content/post/2026/011-simplified-github-ci/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Simplified Single GitHub Actions CI/CD File"
-date: 2026-03-04T00:00:00+00:00
+date: 2026-07-05T13:44:48+10:00
 draft: false
 tags: ["github-actions", "ci", "cd", "go", "node", "dart", "flutter", "qt", "c++", "docker", "goreleaser", "packaging"]
 categories: ["devops", "reference", "automation"]

--- a/content/post/2026/013-resolving-golangci-lint-go-version-conflicts/index.md
+++ b/content/post/2026/013-resolving-golangci-lint-go-version-conflicts/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Resolving golangci-lint Go Version Conflicts in GitHub Actions"
-date: 2026-03-05T00:00:00+00:00
+date: 2026-07-07T21:49:40+10:00
 draft: false
 tags: ["go", "golangci-lint", "github-actions", "ci", "linting", "automation"]
 categories: ["devops", "reference", "go"]

--- a/content/post/2026/014-llm-upgrade-instructions/index.md
+++ b/content/post/2026/014-llm-upgrade-instructions/index.md
@@ -1,6 +1,6 @@
 ---
 title: "LLM Instructions: Upgrading Projects"
-date: "2026-07-07T12:00:00Z"
+date: 2026-07-08T11:33:21+10:00
 draft: false
 tags:
   - llm

--- a/content/post/2026/015-llm-instructions-golangci-lint-version-conflicts/index.md
+++ b/content/post/2026/015-llm-instructions-golangci-lint-version-conflicts/index.md
@@ -1,6 +1,6 @@
 ---
 title: "LLM Instructions: Fixing golangci-lint Go Version Mismatches"
-date: "2026-07-08T02:00:00Z"
+date: 2026-07-10T13:32:21+10:00
 draft: false
 tags:
   - llm

--- a/content/post/2026/016-go-error-handling/index.md
+++ b/content/post/2026/016-go-error-handling/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Effective Error Handling in Go: Wrapping, Sentinels, and Custom Types"
-date: "2026-07-09T06:00:00Z"
+date: 2026-07-10T13:32:59+10:00
 draft: false
 tags:
   - golang

--- a/content/post/2026/017-repoless-explanation-golangci-lint/index.md
+++ b/content/post/2026/017-repoless-explanation-golangci-lint/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Fixing golangci-lint Go Version Mismatch"
-date: "2026-07-10T04:30:00Z"
+date: 2026-07-10T15:57:37+10:00
 draft: false
 tags:
   - golang

--- a/content/post/2026/018-txtar-patterns-for-agents-v2/index.md
+++ b/content/post/2026/018-txtar-patterns-for-agents-v2/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Txtar Test Systems in Practice: Iterating to Scale (v2)"
-date: 2026-02-17T00:00:00+00:00
+date: 2026-07-10T19:12:28+10:00
 draft: false
 tags: ["go", "testing", "txtar", "embed", "golden-files", "agents"]
 categories: ["reference", "testing"]

--- a/content/post/2026/019-llm-compliance-version-upgrades/index.md
+++ b/content/post/2026/019-llm-compliance-version-upgrades/index.md
@@ -1,6 +1,6 @@
 ---
 title: "LLM Compliance: Handling Version Upgrades and golangci-lint"
-date: "2026-07-10T09:00:00Z"
+date: 2026-07-11T13:21:18+10:00
 draft: false
 tags:
   - llm

--- a/content/post/2026/020-optional-dependency-injection-via-type-switched-variadic-args/index.md
+++ b/content/post/2026/020-optional-dependency-injection-via-type-switched-variadic-args/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Go Memory FSs Everywhere in Test: Optional Dependency Injection via Type-Switched Variadic Args"
-date: 2026-03-19T00:00:00+00:00
+date: 2026-07-11T13:03:55+10:00
 draft: false
 tags: ["go", "testing", "architecture", "patterns", "memory-fs", "api-design", "options-pattern"]
 categories: ["engineering-process", "reference"]

--- a/content/post/2026/021-monthly-releases-and-reports/index.md
+++ b/content/post/2026/021-monthly-releases-and-reports/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Automating Monthly Releases and Reports for GitHub Projects"
-date: 2026-07-11T00:00:00Z
+date: 2026-07-12T16:20:36+10:00
 draft: false
 tags: ["github-actions", "automation", "reporting", "static-sites", "seo"]
 categories: ["automation", "best-practices"]

--- a/content/post/2026/022-llm-expand-regex-test/index.md
+++ b/content/post/2026/022-llm-expand-regex-test/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Why LLMs Should Conditionally Avoid Regex and Aim for Exhaustive Test Coverage"
-date: 2026-07-12T00:00:00Z
+date: 2026-07-13T13:33:09+10:00
 draft: false
 tags:
   - llm

--- a/content/post/2026/023-assembling-goreleaser-yaml/index.md
+++ b/content/post/2026/023-assembling-goreleaser-yaml/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Assembling a .goreleaser.yaml File: Standards and Best Practices"
-date: 2026-07-13T04:42:00Z
+date: 2026-07-13T16:58:16+10:00
 draft: false
 tags: ["golang", "goreleaser", "ci", "docker", "release"]
 categories: ["Programming", "Tutorial"]


### PR DESCRIPTION
- Updated all blog post frontmatter dates to strictly match the timestamp they were first merged into the repository.
- Added instructions to `agents.md` so that future agents know to update a post's date field continuously until it is initially merged.
- Verified all frontmatter dates with `git diff`.
- Verified the build with `hugo` command and spellcheck with `cspell`.

---
*PR created automatically by Jules for task [14669415210464632751](https://jules.google.com/task/14669415210464632751) started by @arran4*