### PR TITLE
fix(actions): catch self-collisions in post numbers within the same PR

### DIFF
--- a/.github/scripts/check_post_numbers.py
+++ b/.github/scripts/check_post_numbers.py
@@ -168,7 +168,8 @@ def main():
                 if (year, number) in current_pr_posts:
                     current_folders = current_pr_posts[(year, number)]
                     if folder not in current_folders:
-                        print(f"Error: Collision detected! Current PR {current_pr} uses {year}/{number} for {current_folders}, but lower priority PR {pr} uses it for '{folder}'.")
+                        folders_str = ", ".join(f"'{f}'" for f in current_folders)
+                        print(f"Error: Collision detected! Current PR {current_pr} uses {year}/{number} for {folders_str}, but lower priority PR {pr} uses it for '{folder}'.")
                         conflict_found = True
 
     if conflict_found:

--- a/.github/scripts/check_post_numbers.py
+++ b/.github/scripts/check_post_numbers.py
@@ -108,19 +108,31 @@ def main():
 
     # 1. Get files changed in current PR
     current_pr_files = get_pr_files(repo, current_pr, token)
-    current_pr_posts = {} # (year, number) -> folder
+    current_pr_posts = defaultdict(set) # (year, number) -> set of folders
     current_pr_folders = set()
     for f in current_pr_files:
         year, number, folder = extract_post_info_from_path(f)
         if year is not None and number is not None:
-            current_pr_posts[(year, number)] = folder
+            current_pr_posts[(year, number)].add(folder)
             current_pr_folders.add(folder)
 
     if not current_pr_posts:
         print("No new/modified posts in this PR. Success.")
         sys.exit(0)
 
-    print(f"Posts modified in this PR: {current_pr_posts}")
+    print(f"Posts modified in this PR: {dict(current_pr_posts)}")
+
+    # 1.5 Check for self-collisions within the current PR
+    self_collision = False
+    for (year, number), folders in current_pr_posts.items():
+        if len(folders) > 1:
+            print(f"Error: PR itself contains a collision in year {year} for number {number}. Folders: {', '.join(folders)}")
+            self_collision = True
+
+    if self_collision:
+        print("Self-collision found in current PR. Exiting with error.")
+        sys.exit(1)
+
 
     # 2. Check local collisions, but only fail if they involve folders modified in this PR
     local_posts = get_local_posts()
@@ -154,9 +166,9 @@ def main():
             year, number, folder = extract_post_info_from_path(f)
             if year is not None and number is not None:
                 if (year, number) in current_pr_posts:
-                    current_folder = current_pr_posts[(year, number)]
-                    if current_folder != folder:
-                        print(f"Error: Collision detected! Current PR {current_pr} uses {year}/{number} for '{current_folder}', but lower priority PR {pr} uses it for '{folder}'.")
+                    current_folders = current_pr_posts[(year, number)]
+                    if folder not in current_folders:
+                        print(f"Error: Collision detected! Current PR {current_pr} uses {year}/{number} for {current_folders}, but lower priority PR {pr} uses it for '{folder}'.")
                         conflict_found = True
 
     if conflict_found:


### PR DESCRIPTION
Fixed `.github/scripts/check_post_numbers.py` to properly catch and report post numbering self-collisions within a single pull request. This resolves the issue where a PR modifying two conflicting folders for the same year and number would silently overwrite one another in the tracker until failing obscurely on local disk checks.

---
*PR created automatically by Jules for task [12529250872496024640](https://jules.google.com/task/12529250872496024640) started by @arran4*