### PR TITLE
ci: migrate github pages deployment to native actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,15 +7,10 @@ on:
   pull_request:
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-    permissions:
-      contents: write
-      discussions: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
@@ -29,12 +24,33 @@ jobs:
       - name: Build
         run: hugo --minify
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
+          path: ./public
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    permissions:
+      contents: write
+      discussions: write
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Checkout for discussions
+        uses: actions/checkout@v4
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+        with:
+          fetch-depth: 0
 
       - name: Create Discussions for New Posts
         if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}


### PR DESCRIPTION
Migrates the GitHub Actions workflow for deploying GitHub Pages from using a third-party action that pushes to a branch to the modern, native GitHub Actions artifact deployment method. This uses `actions/upload-pages-artifact` and `actions/deploy-pages`, ensuring more secure and reliable deployments while retaining the existing functionality for automatically creating GitHub Discussions for new blog posts.

---
*PR created automatically by Jules for task [8668632294672717442](https://jules.google.com/task/8668632294672717442) started by @arran4*