### PR TITLE
docs: clarify go-subcommand supports infinite nesting

### DIFF
--- a/content/post/2026/032-go-subcommand-infrastructure/index.md
+++ b/content/post/2026/032-go-subcommand-infrastructure/index.md
@@ -135,6 +135,15 @@ func Restore(...) error {
 
 The shared `vault backup` prefix creates the nested command structure. There is no separate section where the parent-child relationship must be registered.
 
+This structure supports sub-sub commands, and beyond; there is no limit to the depth of nesting. You simply add more words to the command path:
+
+```go
+// Set is a subcommand `vault backup config set`
+func Set(...) error {
+	// ...
+}
+```
+
 The Go function signature defines the values that will be passed to the command. The documentation comment describes how CLI arguments map onto those values.
 
 ## A Practical Backup CLI Grammar


### PR DESCRIPTION
Added a section and code snippet to `032-go-subcommand-infrastructure/index.md` explicitly stating that `go-subcommand` supports infinite subcommand nesting by simply extending the command path. Demonstrated with a 4-level nesting example `vault backup config set`.

---
*PR created automatically by Jules for task [12462444903810591887](https://jules.google.com/task/12462444903810591887) started by @arran4*